### PR TITLE
Added Chip Manufacturers and CERTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Chip Manufacturers
 
 CERTs
 ==================
-* US-CERT: [Vulnerability Note VU#584653 - CPU hardware vulnerable to side-channel attacks](https://www.kb.cert.org/vuls/id/584653)
+* CERT - Carnegie Mellon University: [Vulnerability Note VU#584653 - CPU hardware vulnerable to side-channel attacks](https://www.kb.cert.org/vuls/id/584653)
 
 CPU microcode
 =============

--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ Cloud Providers
 * DigitalOcean: [A Message About Intel Security Findings](https://blog.digitalocean.com/a-message-about-intel-security-findings/)
 * Scaleway: [Emergency security update required on all hypervisors](https://status.online.net/index.php?do=details&task_id=1116)
 
+Chip Manufacturers
+==================
+* Intel: nothing yet
+* AMD: nothing yet
+* ARM: [Security Update](https://developer.arm.com/support/security-update)
+
+CERTs
+==================
+* US-CERT: [Vulnerability Note VU#584653 - CPU hardware vulnerable to side-channel attacks](https://www.kb.cert.org/vuls/id/584653
 
 CPU microcode
 =============

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Chip Manufacturers
 
 CERTs
 ==================
-* US-CERT: [Vulnerability Note VU#584653 - CPU hardware vulnerable to side-channel attacks](https://www.kb.cert.org/vuls/id/584653
+* US-CERT: [Vulnerability Note VU#584653 - CPU hardware vulnerable to side-channel attacks](https://www.kb.cert.org/vuls/id/584653)
 
 CPU microcode
 =============


### PR DESCRIPTION
While this list is intended to keep an eye on patches' releases, it may be useful to include the 'Chip Manufacturers' section for (embedded) devs as well infos for orgs relying on CERTs.